### PR TITLE
Generate fog with CMSAF CLAAS

### DIFF
--- a/src/fogtools/vis.py
+++ b/src/fogtools/vis.py
@@ -33,19 +33,22 @@ def blend_fog(sc, other="overview"):
     return blend
 
 
-def get_fog_blend_for_sat(sensorreader, fl_sat, fl_nwcsaf, area,
-                          blend_background):
+def get_fog_blend_for_sat(sensor_reader, sensor_files,
+                          cloud_reader, cloud_files,
+                          area, blend_background):
     """Get daytime fog blend for sensor
 
     Get a daytime fog blend.
 
     Args:
-        sensorreader (str): For which sensor/reader to derive the fog product.
+        sensor_reader (str): For which sensor/reader to derive the fog product.
             Must be a sensor/reader supported by fogpy.  Currently those are
             "seviri_l1b_hrit" or "abi_l1b".
-        fl_sat (List[str]): List of filenames corresponding to satellite data.
-        fl_nwcsaf (List[str]): List of filenames corresponding to NWCSAF-GEO
-            data.
+        sensor_files (List[str]): List of filenames corresponding to satellite data.
+        cloud_reader (str): Reader providing the cloud products.  Can be
+            "nwcsaf-geo" or "cmsaf-claas2_l2_nc".
+        cloud_files (List[str]): List of filenames corresponding to cloud
+            microphysics data.
         area (str): Area for which to calculate fog.  Must be an AreaDefinition
             defined in satpy (or PPP_CONFIG_DIR), fcitools, or fogtools.
         blend_background (str): Satpy composite to be used as the background
@@ -60,14 +63,16 @@ def get_fog_blend_for_sat(sensorreader, fl_sat, fl_nwcsaf, area,
 
     """
     sc = satpy.Scene(
-        filenames={sensorreader: fl_sat,
-                   "nwcsaf-geo": fl_nwcsaf})
+        filenames={sensor_reader: sensor_files,
+                   cloud_reader: cloud_files})
 
-    D = {"seviri_l1b_hrit": ["IR_108", "IR_087", "IR_016", "VIS006",
-                             "IR_120", "VIS008", "IR_039"],
-         "abi_l1b": ["C02", "C03", "C05", "C07", "C11", "C14", "C15"]}
+    chans = {"seviri_l1b_hrit": ["IR_108", "IR_087", "IR_016", "VIS006",
+                                 "IR_120", "VIS008", "IR_039"],
+             "abi_l1b": ["C02", "C03", "C05", "C07", "C11", "C14", "C15"]}
+    cmic = {"nwcsaf-geo": ["cmic_reff", "cmic_lwp", "cmic_cot"],
+            "cmsaf-claas2_l2_nc": ["reff", "cwp", "cot"]}
 
-    sensor = sensorreader.split("_")[0]
+    sensor = sensor_reader.split("_")[0]
     sattools.ptc.add_all_pkg_comps_mods(sc, ["satpy", "fogpy"],
                                         sensors=[sensor])
     areas = {}
@@ -76,8 +81,8 @@ def get_fog_blend_for_sat(sensorreader, fl_sat, fl_nwcsaf, area,
             areas.update(sattools.ptc.get_all_areas([pkg]))
         except ModuleNotFoundError:
             pass
-    sc.load(["cmic_reff", "cmic_lwp", "cmic_cot", "overview"]
-            + D[sensorreader], unload=False)
+    sc.load(chans[sensor_reader] + cmic[cloud_reader] + ["overview"],
+            unload=False)
     ls = sc.resample(areas[area], unload=False)
     ls.load(["fls_day", "fls_day_extra"], unload=False)
 

--- a/src/fogtools/vis.py
+++ b/src/fogtools/vis.py
@@ -44,7 +44,8 @@ def get_fog_blend_for_sat(sensor_reader, sensor_files,
         sensor_reader (str): For which sensor/reader to derive the fog product.
             Must be a sensor/reader supported by fogpy.  Currently those are
             "seviri_l1b_hrit" or "abi_l1b".
-        sensor_files (List[str]): List of filenames corresponding to satellite data.
+        sensor_files (List[str]): List of filenames corresponding to satellite
+            data.
         cloud_reader (str): Reader providing the cloud products.  Can be
             "nwcsaf-geo" or "cmsaf-claas2_l2_nc".
         cloud_files (List[str]): List of filenames corresponding to cloud

--- a/tests/test_show_fog.py
+++ b/tests/test_show_fog.py
@@ -12,7 +12,8 @@ def test_get_parser(ap):
     fogtools.processing.show_fog.get_parser()
     assert ap.return_value.add_argument.call_count == 4
     assert ap.return_value.add_mutually_exclusive_group.call_count == 2
-    assert ap.return_value.add_mutually_exclusive_group.return_value.add_argument.call_count == 4
+    assert ap.return_value.add_mutually_exclusive_group.return_value.\
+        add_argument.call_count == 4
 
 
 @patch("fogtools.processing.show_fog.parse_cmdline", autospec=True)

--- a/tests/test_show_fog.py
+++ b/tests/test_show_fog.py
@@ -10,7 +10,9 @@ import xarray
 def test_get_parser(ap):
     import fogtools.processing.show_fog
     fogtools.processing.show_fog.get_parser()
-    assert ap.return_value.add_argument.call_count == 7
+    assert ap.return_value.add_argument.call_count == 4
+    assert ap.return_value.add_mutually_exclusive_group.call_count == 2
+    assert ap.return_value.add_mutually_exclusive_group.return_value.add_argument.call_count == 4
 
 
 @patch("fogtools.processing.show_fog.parse_cmdline", autospec=True)
@@ -21,10 +23,9 @@ def test_main(fcS, fvg, fpsp, tmp_path, xrda):
     from satpy import Scene, DatasetID
     fpsp.return_value = fogtools.processing.show_fog.get_parser().parse_args(
             ["/no/out/file",
-             "--sat", "/no/sat/files",
+             "--seviri", "/no/sat/files",
              "--nwcsaf", "/no/nwcsaf/files",
-             "-a", "fribbulus xax",
-             "-m", "seviri_l1b_hrit"])
+             "-a", "fribbulus xax"])
     m_im = MagicMock()
     m_sc = MagicMock()
     f_sc = Scene()
@@ -39,6 +40,7 @@ def test_main(fcS, fvg, fpsp, tmp_path, xrda):
     fvg.assert_called_once_with(
             "seviri_l1b_hrit",
             ["/no/sat/files"],
+            "nwcsaf-geo",
             ["/no/nwcsaf/files"],
             "fribbulus xax",
             "overview")
@@ -47,10 +49,9 @@ def test_main(fcS, fvg, fpsp, tmp_path, xrda):
     fvg.return_value[0].reset_mock()
     fpsp.return_value = fogtools.processing.show_fog.get_parser().parse_args(
             [str(tmp_path),
-             "--sat", "/no/sat/files",
-             "--nwcsaf", "/no/nwcsaf/files",
+             "--abi", "/no/sat/files",
+             "--cmsaf", "/no/nwcsaf/files",
              "-a", "fribbulus xax",
-             "-m", "seviri_l1b_hrit",
              "-i"])
     fogtools.processing.show_fog.main()
     fvg.return_value[0].save.assert_called_once_with(
@@ -64,10 +65,9 @@ def test_main(fcS, fvg, fpsp, tmp_path, xrda):
     fcS.return_value.save_datasets.reset_mock()
     fpsp.return_value = fogtools.processing.show_fog.get_parser().parse_args(
             [str(tmp_path),
-             "--sat", "/no/sat/files",
+             "--seviri", "/no/sat/files",
              "--nwcsaf", "/no/nwcsaf/files",
              "-a", "fribbulus xax",
-             "-m", "seviri_l1b_hrit",
              "-d"])
 
     fogtools.processing.show_fog.main()

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -24,6 +24,7 @@ def test_get_fog_blend_for_sat(fvb, sS, fcS, xrda):
     rv = get_fog_blend_for_sat(
             "seviri_l1b_hrit",
             ["a", "b", "c"],
+            "nwcsaf-geo",
             ["d", "e", "f"],
             "germ",
             "overview")


### PR DESCRIPTION
Change interface to fogpy and to cmdline, adding an option to use CMSAF
CLAAS-2 data for the fog generation.