### PR TITLE
Disable sockets when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - MAIN_CMD="pytest"
-    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml"
+    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml pytest-socket"
     - PIP_DEPENDENCIES=""
     - CONDA_CHANNELS="rttools conda-forge"
     - CONDA_CHANNEL_PRIORITY="strict"

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ exclude =
 testing =
     pytest
     pytest-cov
+    pytest-socket
 
 [options.entry_points]
 console_scripts =
@@ -92,6 +93,7 @@ extras = True
 addopts =
     --cov fogtools --cov-report term-missing
     --verbose
+    --disable-socket
 norecursedirs =
     dist
     build


### PR DESCRIPTION
To make sure my tests aren't accessing network resources, disable
sockets entirely while running the tests.