### PR TITLE
Raise error when running NWCSAF with newer ABI data

### DIFF
--- a/src/fogtools/db.py
+++ b/src/fogtools/db.py
@@ -629,6 +629,9 @@ class _NWCSAF(_CMIC):
         # changes and # start processing automatically when satellite files
         # are added.
 
+        if timestamp > pandas.Timestamp("2019-04-23"):
+            raise FogDBError("ABI-NWCSAF newer than 2019-04-23 not "
+                             "supported, see fogtools#19")
         self.ensure_deps(timestamp)
         if not self.is_running():
             self.start_running()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -509,6 +509,7 @@ class TestNWCSAF:
             fogtools.db._NWCSAF()
 
     def test_store(self, nwcsaf, ts):
+        import fogtools.db
         nwcsaf.ensure_deps = unittest.mock.MagicMock()
         nwcsaf.is_running = unittest.mock.MagicMock()
         nwcsaf.start_running = unittest.mock.MagicMock()
@@ -518,6 +519,8 @@ class TestNWCSAF:
         nwcsaf.is_running.return_value = False
         nwcsaf.store(ts)
         nwcsaf.start_running.assert_called_once_with()
+        with pytest.raises(fogtools.db.FogDBError):
+            nwcsaf.store(pandas.Timestamp("2020-02-03T14:30"))
 
     @unittest.mock.patch("subprocess.run", autospec=True)
     def test_is_running(self, sr, nwcsaf, ts):


### PR DESCRIPTION
When running NWCSAF with newer ABI data, raise an error.