### PR TITLE
Adapt tests to fogpy changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - MAIN_CMD="pytest"
-    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml pytest-socket"
+    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml"
     - PIP_DEPENDENCIES="pytest-subprocess"
     - CONDA_CHANNELS="rttools conda-forge"
     - CONDA_CHANNEL_PRIORITY="strict"

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ exclude =
 testing =
     pytest
     pytest-cov
-    pytest-socket
     pytest-subprocess
 
 [options.entry_points]
@@ -95,7 +94,6 @@ extras = True
 addopts =
     --cov fogtools --cov-report term-missing
     --verbose
-    --disable-socket
     --allow-hosts=127.0.0.1
 norecursedirs =
     dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,6 @@ extras = True
 addopts =
     --cov fogtools --cov-report term-missing
     --verbose
-    --allow-hosts=127.0.0.1
 norecursedirs =
     dist
     build

--- a/tests/test_show_fog.py
+++ b/tests/test_show_fog.py
@@ -18,8 +18,7 @@ def test_get_parser(ap):
 
 @patch("fogtools.processing.show_fog.parse_cmdline", autospec=True)
 @patch("fogtools.vis.get_fog_blend_for_sat", autospec=True)
-@patch("fogpy.composites.Scene", autospec=True)
-def test_main(fcS, fvg, fpsp, tmp_path, xrda):
+def test_main(fvg, fpsp, tmp_path, xrda):
     import fogtools.processing.show_fog
     from satpy import Scene, DatasetID
     fpsp.return_value = fogtools.processing.show_fog.get_parser().parse_args(
@@ -54,16 +53,16 @@ def test_main(fcS, fvg, fpsp, tmp_path, xrda):
              "--cmsaf", "/no/nwcsaf/files",
              "-a", "fribbulus xax",
              "-i"])
-    fogtools.processing.show_fog.main()
-    fvg.return_value[0].save.assert_called_once_with(
+    with patch("satpy.Scene", autospec=True) as sS:
+        fogtools.processing.show_fog.main()
+        fvg.return_value[0].save.assert_called_once_with(
             str(tmp_path / "fog_blend.tif"))
-    fcS.return_value.save_datasets.assert_called_once_with(
-            writer="cf",
-            datasets={"a", "b"},
-            filename=str(tmp_path / "intermediates.nc"))
-    fvg.reset_mock()
-    fvg.return_value[0].reset_mock()
-    fcS.return_value.save_datasets.reset_mock()
+        sS.return_value.save_datasets.assert_called_once_with(
+                writer="cf",
+                datasets={"a", "b"},
+                filename=str(tmp_path / "intermediates.nc"))
+        fvg.reset_mock()
+        fvg.return_value[0].reset_mock()
     fpsp.return_value = fogtools.processing.show_fog.get_parser().parse_args(
             [str(tmp_path),
              "--seviri", "/no/sat/files",

--- a/tests/test_vis.py
+++ b/tests/test_vis.py
@@ -13,13 +13,14 @@ def test_fog_blend(xrda):
     # later, I should do some proper tests of the values here
 
 
-@patch("fogpy.composites.Scene")
 @patch("satpy.Scene")
 @patch("fogtools.vis.blend_fog", autospec=True)
-def test_get_fog_blend_for_sat(fvb, sS, fcS, xrda):
+@patch("requests.get", autospec=True)
+def test_get_fog_blend_for_sat(rg, fvb, sS, xrda):
     from fogtools.vis import get_fog_blend_for_sat
     sS.return_value["overview"] = xrda[0]
     sS.return_value["fls_day"] = xrda[1]
+    rg.return_value.content = b"12345"
     fvb.return_value = sentinel.tofu
     rv = get_fog_blend_for_sat(
             "seviri_l1b_hrit",


### PR DESCRIPTION
Various tests failed due to fogpy changes or earlier poorly tested
changes in fogtools.  Restore those tests.