### PR TITLE
Raise FogDBError when ensuring fails

### DIFF
--- a/src/fogtools/db.py
+++ b/src/fogtools/db.py
@@ -251,6 +251,12 @@ class _DB(abc.ABC):
                          f"{self!s} for {timestamp:%Y-%m-%d %H:%M}, "
                          "downloading / generating")
             self.store(timestamp)
+        if not self.find(timestamp, complete=True):
+            raise FogDBError("I tried to download or generate data for "
+                             f"{self!s} covering {timestamp:%Y-%m-%d %H:%M}, "
+                             "but it's still not there.  Somewhing may have "
+                             "gone wrong trying to download or generate the "
+                             "data.")
 
     def ensure_deps(self, timestamp):
         for (k, dep) in self.dependencies.items():

--- a/src/fogtools/db.py
+++ b/src/fogtools/db.py
@@ -254,7 +254,7 @@ class _DB(abc.ABC):
         if not self.find(timestamp, complete=True):
             raise FogDBError("I tried to download or generate data for "
                              f"{self!s} covering {timestamp:%Y-%m-%d %H:%M}, "
-                             "but it's still not there.  Somewhing may have "
+                             "but it's still not there.  Something may have "
                              "gone wrong trying to download or generate the "
                              "data.")
 


### PR DESCRIPTION
When files are still not found after .ensure() was called, and no
exception was raised downstream, raise a FogDBError.