### PR TITLE
Expand error cathing

### DIFF
--- a/src/fogtools/db.py
+++ b/src/fogtools/db.py
@@ -152,12 +152,12 @@ class FogDB:
                     self.data = df
                 else:
                     self.data = pandas.concat([self.data, df], axis=0)
-            except FogDBError:
+            except (FogDBError, OSError, EOFError):
                 if onerror == "raise":
                     raise
                 elif onerror == "log":
                     logger.exception("Failed to extend database with data "
-                                     f"from {timestamp:%Y-%m-%d %H:%M:%S}")
+                                     f"from {timestamp:%Y-%m-%d %H:%M:%S}:")
                 else:
                     raise ValueError("Unknown error handling option: "
                                      f"{onerror!s}")


### PR DESCRIPTION
When building the fog database, catch not only FogDBError but also
OSError and EOFError.

Closes #39.