### PR TITLE
Limit top n fog cases by time and SZA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   global:
     - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
     - MAIN_CMD="pytest"
-    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml appdirs"
+    - CONDA_DEPENDENCIES="satpy setuptools pyresample pytest-cov coveralls coverage codecov matplotlib pillow pandas s3fs pytables pyarrow tabulate lxml appdirs pyorbital"
     - PIP_DEPENDENCIES="pytest-subprocess"
     - CONDA_CHANNELS="rttools conda-forge"
     - CONDA_CHANNEL_PRIORITY="strict"

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     lxml
     sattools
     appdirs
+    pyorbital
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/fogtools/analysis/fogrank.py
+++ b/src/fogtools/analysis/fogrank.py
@@ -25,6 +25,14 @@ def get_parser():
             default="D", help="Frequency (pandas freq. string) for grouping")
 
     parser.add_argument(
+            "-s", action="store", type=str,
+            default="D", help="Spacing, reporting at most one case per time")
+
+    parser.add_argument(
+            "-a", action="store", type=float,
+            default=70, help="Maximum solar zenith angle")
+
+    parser.add_argument(
             "-f", action="store", choices=["markdown", "csv"],
             default="markdown",
             help="How to present output")
@@ -32,7 +40,7 @@ def get_parser():
     return parser
 
 
-def print_fogs(top_n, vis, freq, form):
+def print_fogs(freq, spacing, max_vis, max_sza, top_n, form):
     """Display the most common fog time periods.
 
     Display to stdout a table of the top_n time periods at which the
@@ -41,12 +49,14 @@ def print_fogs(top_n, vis, freq, form):
     form form.
 
     Args:
-        top_n (int): Number to report.
-        vis (number): Max visibility to consider.
         freq (str or Offset): Frequency to count fogs.
+        spacing (str or Offset): Report at most one per this time.
+        max_vis (number): Max visibility to consider.
+        max_sza (number): Max solar zenith angle.
+        top_n (int): Number to report.
         form (str): Form to write, can be "markdown" or "csv".
     """
-    selec = isd.top_n(freq, vis, top_n)
+    selec = isd.top_n(freq, spacing, max_vis, max_sza, top_n)
     if form == "markdown":
         print(selec.to_markdown(), end="\n")
     elif form == "csv":
@@ -57,4 +67,4 @@ def print_fogs(top_n, vis, freq, form):
 
 def main():
     p = get_parser().parse_args()
-    print_fogs(p.n, p.v, p.p, p.f)
+    print_fogs(p.p, p.s, p.v, p.a, p.n, p.f)

--- a/src/fogtools/processing/build_db.py
+++ b/src/fogtools/processing/build_db.py
@@ -49,7 +49,7 @@ def main():
     log.setup_main_handler()
     fogdb = db.FogDB()
     if p.top_n is not None:
-        top = isd.top_n("H", 1000, p.top_n)
+        top = isd.top_n("H", "D", 1000, 70, p.top_n)
         for dt in top.index:
             fogdb.extend(dt, onerror="log")
     else:

--- a/tests/test_fogdays.py
+++ b/tests/test_fogdays.py
@@ -8,20 +8,22 @@ from unittest.mock import patch
 def test_get_parser(ap):
     import fogtools.analysis.fogrank
     fogtools.analysis.fogrank.get_parser()
-    assert ap.return_value.add_argument.call_count == 4
+    assert ap.return_value.add_argument.call_count == 6
 
 
 @patch("fogtools.isd.read_db")
 def test_main(fir, gb_db):
     import fogtools.analysis.fogrank
     fargp = fogtools.analysis.fogrank.get_parser().parse_args(
-            ["-n", "5", "-v", "1000", "-p", "D", "-f", "csv"])
+            ["-n", "5", "-v", "1000", "-p", "D", "-s", "D",
+             "-a", "70", "-f", "csv"])
     fir.return_value = gb_db
     with patch("fogtools.analysis.fogrank.get_parser") as fafg:
         fafg.return_value.parse_args.return_value = fargp
         fogtools.analysis.fogrank.main()
     fargp = fogtools.analysis.fogrank.get_parser().parse_args(
-            ["-n", "5", "-v", "1000", "-p", "D", "-f", "markdown"])
+            ["-n", "5", "-v", "1000", "-p", "D", "-s", "D",
+             "-a", "70", "-f", "markdown"])
     with patch("fogtools.analysis.fogrank.get_parser") as fafg:
         fafg.return_value.parse_args.return_value = fargp
         fogtools.analysis.fogrank.main()


### PR DESCRIPTION
Choose a smarter limit for the top N fog cases by time and solar zenith angle, so that Fogpy can actually work with these cases and they're not all from the same day: now looking by default for top every hour when SZA < 70°, but limited to at most one case per day.